### PR TITLE
Music & Video Miniapp Refresh Fixes

### DIFF
--- a/src/blocks/MusicBlock.tsx
+++ b/src/blocks/MusicBlock.tsx
@@ -46,8 +46,8 @@ export default class MusicBlock extends Block {
     }
 
     return (
-      <div style={{ backgroundColor: this.theme.palette.secondary.main, width: "100%", height: "100%" }}>
-        {data.title && <h2 className="text-white text-center p-2">{data.title}</h2>}
+      <div style={{ color: this.theme.palette.info.main,backgroundColor: this.theme.palette.secondary.main, width: "100%", height: "100%" }}>
+        {data.title && <h2 style={{ color: this.theme.palette.info.main}} className="text-start p-2">{data.title}</h2>}
         <Iframely
           url={data.url}
           style={{

--- a/src/blocks/VideoBlock.tsx
+++ b/src/blocks/VideoBlock.tsx
@@ -22,14 +22,12 @@ export default class VideoBlock extends Block {
     }
 
     return (
-      <div style={{ backgroundColor: this.theme.palette.secondary.main }}>
-        <div className="flex grow relative w-full h-full min-h-[300px]" style={{ position: 'relative', width: "100%", height: "100%" }}>
-          <ReactPlayer
-            controls={true}
-            url={url}
-            style={{ height: '100%', width: '100%', flexGrow: 1 }}
-          />
-        </div>
+      <div className="flex relative w-full h-auto" style={{ backgroundColor: this.theme.palette.secondary.main }}>
+        <ReactPlayer
+          controls={true}
+          url={url}
+          className="w-full h-auto"
+        />
       </div>
     );
   }


### PR DESCRIPTION
- Video Miniapp no longer overflows the feed for extra wide videos.
- React player controls should always be visible now.

- Old music posts / music miniapps on deprecated cards that contain a title will now render properly. 