### PR TITLE
AccountModel added to Miniapps

### DIFF
--- a/docs/miniapp-creation/composer-component.md
+++ b/docs/miniapp-creation/composer-component.md
@@ -30,6 +30,18 @@ model.data['text'] = "New User Text Here!"
 ```
 Make sure not to store any data in here that is too large, for performance reasons. If you want to store images, videos, or other large files, you can use our [FileUploader]() component, and store the URL as a string in the model.
 
+### Accessing User Data
+
+All account data gets stored in the `AccountModel` which is a key-value store which holds strings, not unlike the `BlockModel`. 
+
+Accessing a seam user's account information can be done via the model's `account` property:
+```
+model.account.id  // Returns the unique account object ID of the miniapp user.
+model.account.username  // Returns the unique Seam username of the miniapp user.
+model.account.profilePhoto  // Returns the URL for the Seam profile picture of the miniapp user.
+model.account.badges  // Returns an array of badge names the miniapp user has earned.
+```
+
 ### Posting
 
 Once the user is done in your miniapp, call the done function with the updated model. This will automatically advance the composer to the preview step. For example from the Camera miniapp:

--- a/docs/miniapp-creation/composer-component.md
+++ b/docs/miniapp-creation/composer-component.md
@@ -30,18 +30,6 @@ model.data['text'] = "New User Text Here!"
 ```
 Make sure not to store any data in here that is too large, for performance reasons. If you want to store images, videos, or other large files, you can use our [FileUploader]() component, and store the URL as a string in the model.
 
-### Accessing User Data
-
-All account data gets stored in the `AccountModel` which is a key-value store which holds strings, not unlike the `BlockModel`. 
-
-Accessing a seam user's account information can be done via the model's `account` property:
-```
-model.account.id  // Returns the unique account object ID of the miniapp user.
-model.account.username  // Returns the unique Seam username of the miniapp user.
-model.account.profilePhoto  // Returns the URL for the Seam profile picture of the miniapp user.
-model.account.badges  // Returns an array of badge names the miniapp user has earned.
-```
-
 ### Posting
 
 Once the user is done in your miniapp, call the done function with the updated model. This will automatically advance the composer to the preview step. For example from the Camera miniapp:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,7 @@ export default function App() {
   const [loadedPosts, setLoadedPosts] = useState<BlockModel[]>([
     {
       type: 'FlashingText',
-      account: {id: "", username: ""},
+      account: {},
       data: {
         text: 'Welcome to the Seam Miniapp Builder!',
       },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ export default function App() {
   const [loadedPosts, setLoadedPosts] = useState<BlockModel[]>([
     {
       type: 'FlashingText',
+      account: {id: "", username: ""},
       data: {
         text: 'Welcome to the Seam Miniapp Builder!',
       },

--- a/src/Composer/BlockSelectorModal.js
+++ b/src/Composer/BlockSelectorModal.js
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { nanoid } from 'nanoid';
 import BlockFactory from '../blocks/BlockFactory';
 
-const BlockSelectorModal = ({ selectedBlockType, initialBlockData, setSelectedBlockData }) => {
+const BlockSelectorModal = ({ account, selectedBlockType, initialBlockData, setSelectedBlockData }) => {
   const [width, setWidth] = useState(undefined);
   const divRef = useRef(null);
   const isFullscreenEdit = BlockFactory.doesBlockEditFullscreen(selectedBlockType);
@@ -19,6 +19,7 @@ const BlockSelectorModal = ({ selectedBlockType, initialBlockData, setSelectedBl
 
   const model = {
     type: selectedBlockType,
+    account: account,
     data: initialBlockData || {},
     uuid: nanoid()  // Generate a new unique ID
   };

--- a/src/Composer/Composer.js
+++ b/src/Composer/Composer.js
@@ -176,6 +176,7 @@ function Composer({ addNewPost }) {
         />
       </div>
       <BlockSelectorModal
+        account={{id: "abcd", username: "FrankieTheStar", badges: [{type: "og"}], profilePhoto: "https://upcdn.io/W142hWW/raw/uploads/2024/02/23/start-4skb.png" }}
         selectedBlockType={state.selectedBlockType.type}
         initialBlockData={state.selectedBlockData?.data ?? {}}
         setSelectedBlockData={(data) => {

--- a/src/Composer/Composer.js
+++ b/src/Composer/Composer.js
@@ -176,7 +176,7 @@ function Composer({ addNewPost }) {
         />
       </div>
       <BlockSelectorModal
-        account={{id: "4CKMNhPiZu", username: "FrankieTheStar", badges: [{type: "og"}], profilePhoto: "https://upcdn.io/W142hWW/raw/uploads/2024/02/23/start-4skb.png" }}
+        account={{spotifyAccount: "YOUR_AUTHORIZED_SPOTIFY_ACCOUNT_DETAILS"}}
         selectedBlockType={state.selectedBlockType.type}
         initialBlockData={state.selectedBlockData?.data ?? {}}
         setSelectedBlockData={(data) => {

--- a/src/Composer/Composer.js
+++ b/src/Composer/Composer.js
@@ -176,7 +176,7 @@ function Composer({ addNewPost }) {
         />
       </div>
       <BlockSelectorModal
-        account={{id: "abcd", username: "FrankieTheStar", badges: [{type: "og"}], profilePhoto: "https://upcdn.io/W142hWW/raw/uploads/2024/02/23/start-4skb.png" }}
+        account={{id: "4CKMNhPiZu", username: "FrankieTheStar", badges: [{type: "og"}], profilePhoto: "https://upcdn.io/W142hWW/raw/uploads/2024/02/23/start-4skb.png" }}
         selectedBlockType={state.selectedBlockType.type}
         initialBlockData={state.selectedBlockData?.data ?? {}}
         setSelectedBlockData={(data) => {

--- a/src/blocks/types.tsx
+++ b/src/blocks/types.tsx
@@ -38,10 +38,7 @@ export type BlockModel = {
 };
 
 export interface AccountModel {
-  readonly id: string;
-  readonly username: string;
-  readonly badges?: Badge[];
-  readonly profilePhoto?: string;
+  readonly spotifyAccount?: any;
 }
 
 export interface Badge {

--- a/src/blocks/types.tsx
+++ b/src/blocks/types.tsx
@@ -32,9 +32,23 @@ import localelocatrIcon from "./blockIcons/localelocatrIcon.png";
 
 export type BlockModel = {
   type: string;
+  account: ReadOnlyAccountModel;
   data: { [key: string]: string };
   uuid: string; // must be unique to avoid layout issues
 };
+
+export interface ReadOnlyAccountModel {
+  readonly id: string;
+  readonly username: string;
+  readonly badges?: Badge[];
+  readonly profilePhoto?: string;
+  readonly SpotifyAccount?: {};
+}
+
+export interface Badge {
+  date: string; // Badge earn date
+  type: string; // Badge name
+}
 
 export interface FeedComponentProps {
   model: BlockModel;
@@ -457,4 +471,15 @@ export const BlockTypes: { [key: string]: BlockType } = {
     createdBy: "seam",
     fullscreenEdit: false,
   },
+  "Testing": { 
+    type: "Testing",
+    displayName: "testing",
+    displayDescription: "testing 123",
+    icon: voiceNoteIcon, // TODO: insert your app icon here
+    deprecated: false,
+    doesBlockPost: true,
+    doesBlockEdit: true,
+    createdBy: "jamesburet",
+    fullscreenEdit: false,
+},
 };

--- a/src/blocks/types.tsx
+++ b/src/blocks/types.tsx
@@ -469,15 +469,4 @@ export const BlockTypes: { [key: string]: BlockType } = {
     createdBy: "seam",
     fullscreenEdit: false,
   },
-  "Testing": { 
-    type: "Testing",
-    displayName: "testing",
-    displayDescription: "testing 123",
-    icon: voiceNoteIcon, // TODO: insert your app icon here
-    deprecated: false,
-    doesBlockPost: true,
-    doesBlockEdit: true,
-    createdBy: "jamesburet",
-    fullscreenEdit: false,
-},
 };

--- a/src/blocks/types.tsx
+++ b/src/blocks/types.tsx
@@ -42,7 +42,6 @@ export interface AccountModel {
   readonly username: string;
   readonly badges?: Badge[];
   readonly profilePhoto?: string;
-  readonly SpotifyAccount?: {};
 }
 
 export interface Badge {

--- a/src/blocks/types.tsx
+++ b/src/blocks/types.tsx
@@ -32,12 +32,12 @@ import localelocatrIcon from "./blockIcons/localelocatrIcon.png";
 
 export type BlockModel = {
   type: string;
-  account: ReadOnlyAccountModel;
+  account: AccountModel;
   data: { [key: string]: string };
   uuid: string; // must be unique to avoid layout issues
 };
 
-export interface ReadOnlyAccountModel {
+export interface AccountModel {
   readonly id: string;
   readonly username: string;
   readonly badges?: Badge[];
@@ -46,7 +46,6 @@ export interface ReadOnlyAccountModel {
 }
 
 export interface Badge {
-  date: string; // Badge earn date
   type: string; // Badge name
 }
 


### PR DESCRIPTION
### Accessing account data from a Miniapp

All account data gets stored in the `AccountModel` which is a key-value store which holds strings, not unlike the `BlockModel`. 

Accessing a seam user's account information can be done via the model's `account` property:
```
model.account.id  // Returns the unique account object ID of the miniapp user.
model.account.username  // Returns the unique Seam username of the miniapp user.
model.account.profilePhoto  // Returns the URL for the Seam profile picture of the miniapp user.
model.account.badges  // Returns an array of badge names the miniapp user has earned.
```

