### PR TITLE
Fix MagicCard app text alignment on mobile devices

### DIFF
--- a/src/blocks/MagicCardApp.tsx
+++ b/src/blocks/MagicCardApp.tsx
@@ -754,7 +754,7 @@ const MagicCard = forwardRef((props: MagicCardProps, ref: React.ForwardedRef<HTM
     }
 
     ctx.fillStyle = "black";
-    ctx.textBaseline = "top";
+    ctx.textBaseline = "alphabetic";
     ctx.textAlign = "left";
 
     ctx.drawImage(illustrationImg, 63, 122, ILLUSTRATION_WIDTH, ILLUSTRATION_HEIGHT);
@@ -762,11 +762,26 @@ const MagicCard = forwardRef((props: MagicCardProps, ref: React.ForwardedRef<HTM
     ctx.drawImage(frameImg, 40, 40);
 
     ctx.font = "bold 48px MagicCard";
-    ctx.fillText(props.cardName, 68, 62, 610);
+    ctx.fillText(props.cardName, 68, 100, 610);
 
     ctx.font = "bold 40px MagicCard";
     const textWidth = ctx.measureText(props.type).width;
-    ctx.fillText(props.type, 68, 592, 610);
+    ctx.fillText(props.type, 68, 622, 610);
+
+    // draw subtype
+    if (props.subType !== "") {
+      // line separating type and subtype
+      const spacing = 8;
+      const barWidth = 25;
+      ctx.fillRect(68 + textWidth + spacing, 614, barWidth, 2);
+      // draw subtype
+      ctx.fillText(
+        props.subType,
+        68 + textWidth + spacing * 2 + barWidth,
+        622,
+        610 - textWidth - spacing * 2 - barWidth
+      );
+    }
 
     // draw mana cost
     const manaCostPlaceholders: Array<keyof typeof resources.icons> = [];
@@ -797,23 +812,6 @@ const MagicCard = forwardRef((props: MagicCardProps, ref: React.ForwardedRef<HTM
       x -= manaImageSize + 1.5;
     }
 
-    ctx.font = "bold 40px MagicCard";
-
-    // draw subtype
-    if (props.subType !== "") {
-      // line separating type and subtype
-      const spacing = 8;
-      const barWidth = 25;
-      ctx.fillRect(68 + textWidth + spacing, 614, barWidth, 2);
-      // draw subtype
-      ctx.fillText(
-        props.subType,
-        68 + textWidth + spacing * 2 + barWidth,
-        592,
-        610 - textWidth - spacing * 2 - barWidth
-      );
-    }
-
     // draw power and toughness
     if (props.power !== "" && props.toughness !== "") {
       // draw the pt box
@@ -822,7 +820,7 @@ const MagicCard = forwardRef((props: MagicCardProps, ref: React.ForwardedRef<HTM
       ctx.font = "bold 40px MagicCard";
       ctx.textAlign = "center";
       const ptText = `${props.power}/${props.toughness}`;
-      ctx.fillText(ptText, 542 + ptBoxImg.width / 2, 930, ptBoxImg.width - 50);
+      ctx.fillText(ptText, 542 + ptBoxImg.width / 2, 965, ptBoxImg.width - 50);
       ctx.textAlign = "left";
     }
 
@@ -830,7 +828,7 @@ const MagicCard = forwardRef((props: MagicCardProps, ref: React.ForwardedRef<HTM
     // the rules are centered vertically in the box
     let lineHeight = 35;
     const startX = 68; // starting x
-    const startY = 654; // starting y
+    const startY = 679; // starting y
     let y = startY;
     const maxWidth = 610;
     const maxHeight = 270;
@@ -881,7 +879,7 @@ const MagicCard = forwardRef((props: MagicCardProps, ref: React.ForwardedRef<HTM
             x += partLength;
             lastPartIndex = index + 3; // {x} -> 3 characters
 
-            ctx.drawImage(placeholderImages[icon], x, y + 2, 25, 25);
+            ctx.drawImage(placeholderImages[icon], x, y - 22, 25, 25);
             x += 25; // icon width
           }
 


### PR DESCRIPTION
Canvas on Android Chrome is not respecting the ctx.textBaseline property, and it looks like the default of `alphabetic` is being used no matter what. So this PR just sets the textBaseline as alphabetic and all the fillText calls are adjusted to the new baseline.

before fix:
![image](https://github.com/user-attachments/assets/05133535-aacf-4056-9da5-6af8b2cdb70b)

after fix: 
![image](https://github.com/user-attachments/assets/6c5ac0c2-c638-4c8c-b78b-7847c538b8f9)


