### PR TITLE
Fix: Layered Image

### DIFF
--- a/src/blocks/LayeredImageBlock.tsx
+++ b/src/blocks/LayeredImageBlock.tsx
@@ -178,7 +178,8 @@ const SliderCounter = (props: { images: string[], count: number, mode: boolean }
           className='slider'
           style={{
             display: "flex",
-            alignItems: "center"
+            alignItems: "center",
+            justifyContent: "space-between"
           }}
         >
           <input
@@ -193,7 +194,7 @@ const SliderCounter = (props: { images: string[], count: number, mode: boolean }
             onTouchEnd={snapValue}
 
           />
-          <p style={{ whiteSpace: 'nowrap', width: "7%", textAlign: "end" }}>{currentImage + 1} / {ImgCount}</p>
+          <p style={{ whiteSpace: 'nowrap', width: "60px", textAlign: "right"}}>{currentImage + 1} / {ImgCount}</p>
         </div>
       </div>
     </div>

--- a/src/blocks/assets/LayeredImageBlock/LayeredImageStyles.css
+++ b/src/blocks/assets/LayeredImageBlock/LayeredImageStyles.css
@@ -7,11 +7,11 @@
     appearance: none;          
     padding: 0px;
     margin: 0px;
-    width: 100%;
+    width: 90%;
     height: 10px;
     border-radius: 20px;
     margin-right: 12px;
-    flex-grow: inherit;
+    flex-grow: 0;
     Border: 2px solid #0051E8;
   }
 


### PR DESCRIPTION
## Minor Cosmetic Fixes for the Layered Image Miniapp

This pull request addresses several cosmetic issues in the Layered Image Miniapp, particularly in the composer and mobile views. Note that some issues are only visible in the app and not reproducible in the Miniapp Builder (marked with *).

Issues Fixed:
- *Button and image cards are cut off in Step 2 of the composer.
- *Images do not have rounded corners, except for the first image.
- *Slider is difficult to grab without scrolling or swiping.
- Slider snapping doesn't work properly on mobile.
- *Slider border radius changes between the feed and focused view (Slider track has less border radius in focused mode).
- Frame numbers overflow when the frame count reaches 10.

The corresponding fixes have been implemented in the commits listed below.
