### PR TITLE
Image fallback component

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "framer-motion": "^11.3.27",
     "p5": "^1.9.4",
     "react": "^18.2.0",
-    "react-color": "^2.19.3",
+    "react-color": "2.17.3",
     "react-dom": "^18.2.0",
     "react-feather": "^2.0.10",
     "react-geocode": "^1.0.0-alpha.1",

--- a/src/blocks/utils/ImageWithFallback.tsx
+++ b/src/blocks/utils/ImageWithFallback.tsx
@@ -1,0 +1,41 @@
+import React, { useState, useEffect } from 'react';
+
+interface ImageWithFallbackProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  fallbackSrc: string;
+}
+
+const ImageWithFallback: React.FC<ImageWithFallbackProps> = ({ src, fallbackSrc, ...props }) => {
+  const [imgSrc, setImgSrc] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    let isMounted = true;
+    const testImage = new Image();
+    testImage.src = src as string;
+
+    testImage.onload = () => {
+      if (isMounted) {
+        setImgSrc(src);
+      }
+    };
+
+    testImage.onerror = () => {
+      if (isMounted) {
+        setImgSrc(fallbackSrc);
+      }
+    };
+
+    return () => {
+      isMounted = false;
+    };
+  }, [src, fallbackSrc]);
+
+  if (imgSrc === undefined) {
+    return (
+      <div style={{ width: '100%', height: '100%', backgroundColor: '#f0f0f0' }} />
+    );
+  }
+
+  return <img src={imgSrc} {...props} />;
+};
+
+export default ImageWithFallback;

--- a/src/blocks/utils/ImageWithModal.tsx
+++ b/src/blocks/utils/ImageWithModal.tsx
@@ -7,6 +7,7 @@ import 'swiper/css/zoom';
 import { Navigation, Zoom } from 'swiper/modules';
 import { createPortal } from 'react-dom';
 import CloseIcon from '@mui/icons-material/Close';
+import ImageWithFallback from './ImageWithFallback';
 
 // Initialize Swiper modules
 SwiperCore.use([Navigation, Zoom]);
@@ -77,7 +78,15 @@ const ImageWithModal: FC<ImageWithModalProps> = ({ urls, style }) => {
     <>
       <div className="flex cursor-pointer gap-2.5">
         {urls.map((src, index) => (
-          <img key={index} src={downscaledURL(src)} className="object-cover" style={style} alt="Thumbnail" onClick={handleOpen(index)} />
+          <ImageWithFallback
+            key={index}
+            src={downscaledURL(src)}
+            fallbackSrc={src}
+            className="object-cover"
+            style={style}
+            alt="Thumbnail"
+            onClick={handleOpen(index)}
+          />
         ))}
       </div>
 


### PR DESCRIPTION
- Added `ImageWithFallback.tsx` to the utils folder. 
- Use `ImageWithFallback.tsx` in the `ImageWithModal.tsx` so that if the downscaledURL cannot be fetched, we fallback on the full res image instead of a blank thumbnail.

----

* Downgraded react-color from 2.19.3 to 2.17.3 to fix an issue with Seam's frontend color picker. 